### PR TITLE
Add missing negotiator package to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   },
   "dependencies": {
     "boom": "^2.6.0",
-    "hoek": "^2.8.1"
+    "hoek": "^2.8.1",
+    "negotiator": "^0.4.9"
   }
 }


### PR DESCRIPTION
Hey,

I added `negotiator` to the `package.json` file. It was missing as a dependency.
