### PR TITLE
Fix #4 - respect failed preconditions

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -14,6 +14,11 @@ exports.register = function (plugin,options,next) {
   var config = Hoek.applyToDefaults(defaults, options);
 
   plugin.ext('onPreResponse', function (request, reply) {
+    var statusCode = request.response.output.statusCode;
+    if (statusCode && statusCode >= 400) {
+      return reply.continue();
+    }
+	  
     var requestSettings = request.route.settings.plugins['hapi-negotiator'];
 
     if (requestSettings === false) {


### PR DESCRIPTION
Hapi's onPreResponse handler is always executed, even if a request failed due to some preconditions. As such there is need to check for an error here, and just continue with the error reply.