### PR TITLE
Vary on "accept" header

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -49,6 +49,17 @@ exports.register = function (plugin,options,next) {
     }
   });
 
+
+  plugin.ext('onPreResponse', function(request, reply) {
+    var requestSettings = request.route.settings.plugins['hapi-negotiator'];
+
+    if(request.response && request.response.vary && requestSettings !== false) {
+      request.response.vary('accept');
+    }
+
+    reply.continue();
+  });
+
   next();
 };
 


### PR DESCRIPTION
This will make it so for example if you have Varnish and have a HTML and JSON response, it will cache them separately.
