### PR TITLE
Skip plugin if falsey config

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -16,7 +16,7 @@ exports.register = function (plugin,options,next) {
   plugin.ext('onPostHandler', function (request, reply) {
     var requestSettings = request.route.settings.plugins['hapi-negotiator'];
 
-    if (requestSettings === false) {
+    if (requestSettings == false) {
       return reply.continue();
     }
 


### PR DESCRIPTION
Taking a punt on the expected behaviour here - currently this plugin is always enabled unless you explicitly disable it by setting it to `false`.

This PR skips the plugin for a route if there's no config for it (i.e. if config is falsey - null, undefined, false etc.).
